### PR TITLE
Create boot directory

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -1,0 +1,16 @@
+QEMU=qemu-system-x86_64
+BOOT=boot.bin
+NS=nasm
+BIN_FILES=$(subst .asm,.bin,$(wildcard *.asm))
+.PHONY: clear run
+
+all:$(BIN_FILES)
+
+%.bin:%.asm
+	$(NS) $< -f bin -o $@
+
+run:
+	$(QEMU) -hda $(BOOT)
+
+clear:
+	rm $(BIN_FILES)

--- a/boot/README.md
+++ b/boot/README.md
@@ -1,0 +1,14 @@
+# description
+This README file is a log or document during learning.
+
+# doc
+The BIOS in modern PCs initializes and tests the system hardware components (Power-on self-test), and loads a boot loader from a mass storage device which then initializes an operating system. The BIOS recognizes the boot device by magic numbers. These numbers are 0x55 and 0xAA, or 85 and 170 in decimal appropriately. Also, these magic numbers must be located exactly in bytes 511 and 512 in our bootable device. When the BIOS finds such a boot sector, it loads it into memory at a specific address — 0x0000:0x7C00.<br/><br/>
+
+Because CPU is in protected mode(16 bits) and qemu uses the legacy BIOS(UEFI BIOS have firmware to set CPU to real mode), our bootloader should be set to 16 bits using assembly instruction "bits 16".<br/><br/>
+
+For now, we build a very simple bootloader which is only able to display "Hello, runOS". The bootloader is loacted on the harddisk's MBR(.bin file follows qemu option -hda).
+
+# use
+cd ./boot/
+compile: make
+run: make run

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -1,0 +1,27 @@
+; CPU is in protected mode(16 bit) after powering on. And qemu initialization
+; uses the legacy BIOS that must work in 16-bit mode. So our bootloader is set
+; to 16 bit.
+
+org 0x7c00                  ; Tell the compiler this program is start at ox7c00
+bits 16                     ; Tell the compiler the program run in 16-bit mode
+
+start:
+    cli
+    mov si, msg
+    mov ah, 0x0e
+loop:
+    lodsb
+    or al, al
+    jz pause
+    int 0x10
+    jmp loop
+
+msg:
+    db "Hello runOS", 0
+pause:
+    jmp $
+
+; Magic numbers for BIOS to identify the
+; sector and load the bootloader into memory
+times 510 - ($ - $$) db 0
+dw 0xaa55                   ; Magic Number


### PR DESCRIPTION
For now, we build a very simple bootloader which is only able to display "Hello, runOS". The bootloader is loacted on the harddisk's MBR(.bin file follows qemu option -hda).