### PR TITLE
boot: mov bootloader to initial position

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -2,7 +2,7 @@ QEMU=qemu-system-x86_64
 BOOT=boot.bin
 NS=nasm
 BIN_FILES=$(subst .asm,.bin,$(wildcard *.asm))
-.PHONY: clear run
+.PHONY: clean run
 
 all:$(BIN_FILES)
 
@@ -12,5 +12,5 @@ all:$(BIN_FILES)
 run:
 	$(QEMU) -hda $(BOOT)
 
-clear:
+clean:
 	rm $(BIN_FILES)

--- a/boot/README.md
+++ b/boot/README.md
@@ -6,9 +6,9 @@ The BIOS in modern PCs initializes and tests the system hardware components (Pow
 
 Because CPU is in protected mode(16 bits) and qemu uses the legacy BIOS(UEFI BIOS have firmware to set CPU to real mode), our bootloader should be set to 16 bits using assembly instruction "bits 16".<br/><br/>
 
-For now, we build a very simple bootloader which is only able to display "Hello, runOS". The bootloader is loacted on the harddisk's MBR(.bin file follows qemu option -hda).
+The bootloader is loacted on the harddisk's MBR(.bin file follows qemu option -hda).
 
 # use
-cd ./boot/
-compile: make
-run: make run
+cd ./boot/<br/>
+compile: make<br/>
+run: make run<br/>

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -2,22 +2,40 @@
 ; uses the legacy BIOS that must work in 16-bit mode. So our bootloader is set
 ; to 16 bit.
 
+; The goal of this program:
+; 1. Mov the the program itself to 0x90000;
+; 2. Load the module of setup;
+; 3. Load the module of system;
+; 4. jump to setup and run
+BOOTSEG equ 0x07c0
+INITSEG equ 0x5000
+MOVCOUNT equ 0x100          ; Mov 256 x 2 bytes(MBR is 512 bytes)
+STACKPOS equ 0xff00
+
 org 0x7c00                  ; Tell the compiler this program is start at ox7c00
 bits 16                     ; Tell the compiler the program run in 16-bit mode
 
-start:
-    cli
-    mov si, msg
-    mov ah, 0x0e
-loop:
-    lodsb
-    or al, al
-    jz pause
-    int 0x10
-    jmp loop
+global _start
 
-msg:
-    db "Hello runOS", 0
+_start:
+    mov ax,BOOTSEG
+    mov es,ax
+    mov ax,INITSEG
+    mov ds,ax
+    sub si,si
+    sub di,di
+    mov cx,MOVCOUNT
+    cld                     ; Set DF flag to 0, movw forward transmission
+    repe movsw              ; repeat movw for cx times
+    jmp INITSEG:setseg
+
+setseg:
+    mov ax,cs
+    mov ds,ax
+    mov es,ax
+    mov ss,ax
+    mov sp,STACKPOS         ; Stack position is es:sp = 0x9000:0xff00
+
 pause:
     jmp $
 


### PR DESCRIPTION
Bootloader can mov itself to initial position (address is set by variable INITSEG, not it's 0x5000:0x0000). However if the initial position is set to 0x9000 that is same with linux-0.11, qemu would report error of "execute code outside RAM or ROM at 0x00000000000a0000". The root cause is not yet clear.